### PR TITLE
Finance usability fixes

### DIFF
--- a/finances/balance_expenses.py
+++ b/finances/balance_expenses.py
@@ -34,6 +34,8 @@ if __name__ == '__main__':
 
     total = 0.0
     paid = dict()
+    for user in weights.keys():
+        paid[user] = 0.0
 
     heading_row_counted = False
     with open(args.csv_file) as csvfile:

--- a/finances/balance_expenses.py
+++ b/finances/balance_expenses.py
@@ -12,6 +12,7 @@ def parse_args():
 
     parser.add_argument("csv_file", help="File for which to calculate equalization payments")
     parser.add_argument("--log-level", "-l", default='INFO', help="Level of extra messages")
+    parser.add_argument("--config", "-c", default=None, help="Config library to import")
 
     return parser.parse_args()
 
@@ -24,8 +25,16 @@ if __name__ == '__main__':
 
     logger.debug(args.csv_file)
 
+    if args.config:
+        import importlib
+        cfg = importlib.import_module(args.config)
+        weights = cfg.weights
+    else:
+        from config import weights
+
     total = 0.0
     paid = dict()
+
     heading_row_counted = False
     with open(args.csv_file) as csvfile:
         reader = csv.reader(csvfile, delimiter=',')
@@ -49,18 +58,27 @@ if __name__ == '__main__':
             cost = float(cost)
 
             total += cost
+
+            assert user in weights.keys(), f"Contributor {user} weight unspecified in config!"
             if user not in paid.keys():
                 paid[user] = cost
             else:
                 paid[user] += cost
 
     print(f'total: {total}')
-    fair_share = total / len(paid.keys())
-    print(f'fair share: {round(fair_share, 2)}')
+    shares = 0
+    for weight in weights.values():
+        shares += weight
 
+    share_price = total / shares
+    print(f'fair share: {round(share_price, 2)}')
+    print()
+    for user, weight in weights.items():
+        print(f"{user} pays {weight} shares out of {shares} total")
+    print()
     logger.debug(paid)
     for k, v in paid.items():
-        paid[k] = v - fair_share
+        paid[k] = v - share_price * weights[k]
 
     logger.debug(f'current: {paid}')
     for k1 in paid.keys():

--- a/finances/balance_expenses.py
+++ b/finances/balance_expenses.py
@@ -26,6 +26,7 @@ if __name__ == '__main__':
 
     total = 0.0
     paid = dict()
+    heading_row_counted = False
     with open(args.csv_file) as csvfile:
         reader = csv.reader(csvfile, delimiter=',')
 
@@ -35,8 +36,17 @@ if __name__ == '__main__':
 
             logger.debug(row)
             # 2021-01-01,Person 1,1.23,food from today
-            date, user, _, note = row
-            cost = float(row[2])
+            date, user, cost, note = row
+            if date == "Date" and user == "Contributor" and note == "Notes":
+                if not heading_row_counted:
+                    heading_row_counted = True
+                    logger.debug("Heading row detected! Skipping")
+                else:
+                    logger.debug("Heading row detected again! That's weird")
+
+                continue
+
+            cost = float(cost)
 
             total += cost
             if user not in paid.keys():

--- a/finances/breakdown.py
+++ b/finances/breakdown.py
@@ -13,6 +13,7 @@ def parse_args():
     parser.add_argument("csv_file", help="File to categorize")
     parser.add_argument("--log-level", "-l", default='INFO', help="Level of extra messages")
     parser.add_argument("--config", "-c", default=None, help="Config library to import")
+    parser.add_argument("--group", "-g", action="store_true", help="Group common expenses together")
 
     return parser.parse_args()
 
@@ -46,6 +47,14 @@ if __name__ == '__main__':
             if cfg.check_skip(desc):
                 logger.debug("{} is on the list. Skipping.".format(desc))
                 continue
+
+            if args.group:
+                for k, v in cfg.replace_regex.items():
+                    if k in desc:
+                        old_len = len(desc)
+                        new_len = len(v)
+                        assert new_len < old_len
+                        desc = v + " " * (old_len - new_len)
 
             logger.debug("{}: charged ({}) paid ({})".format(desc, charged, paid))
 

--- a/finances/config.py
+++ b/finances/config.py
@@ -15,6 +15,12 @@ replace_regex = {
     "ANDTHIS": "With That",
 }
 
+weights = {
+    "Person1": 1,
+    "Person2": 1,
+    "Person3": 2,
+}
+
 
 # return whether input description is included in the descriptions to skip
 def check_skip(desc):

--- a/finances/config.py
+++ b/finances/config.py
@@ -10,6 +10,11 @@
 
 skip_regex = list()
 
+replace_regex = {
+    "REPLACETHIS": "With This",
+    "ANDTHIS": "With That",
+}
+
 
 # return whether input description is included in the descriptions to skip
 def check_skip(desc):


### PR DESCRIPTION
Enhance usability of manual actions in code.
* balance_expenses.py
** Detect and ignore header row to allow for wanton CSV saving
** Specify weights per contributor to avoid the need for duplicate entries for those who agreed to pay more
** Populate initial state from configured contributors to account for deadbeats
* breakdown.py
** Allow expenses that fall into the same category to be counted together